### PR TITLE
Tolerate dub noise remix

### DIFF
--- a/flycheck-dmd-dub.el
+++ b/flycheck-dmd-dub.el
@@ -102,8 +102,11 @@ PKG is a package name such as 'cerealed': '~master'."
 
 (defun fldd--get-dub-package-dirs ()
   "Get package directories."
-  (let ((default-directory (fldd--get-project-dir)))
-    (fldd--get-dub-package-dirs-json (json-read-from-string (shell-command-to-string "dub describe")))))
+  (let* ((default-directory (fldd--get-project-dir))
+         (command-output (replace-regexp-in-string "^\\([[:ascii:][:nonascii:]]*?\\){.*\\'" ""
+                                                   (shell-command-to-string "dub describe")
+                                                   nil nil 1)))
+    (fldd--get-dub-package-dirs-json (json-read-from-string command-output))))
 
 
 ;;;###autoload


### PR DESCRIPTION
I had an interesting bug where flycheck-dmd-dub-set-include-path froze emacs for a while on a new project, then threw an error and failed to work until being run a second time explicitly. Turns out "dub describe" was fetching stuff and though it returned the JSON data, there was a bunch of junk before it, such as:

"The following changes will be performed:\nFetch vibe-d >=0.7.17, userWide\nFetch libevent ~master, userWide\nFetch openssl ~master,"

I've truncated that string to protect the innocent. Anyway I figured it might be nice to skip everything up to the first opening brace before trying to parse the JSON.

Aren't elisp regexps cute.

Cheers
