### PR TITLE
Tolerate text from dub before start of json

### DIFF
--- a/flycheck-dmd-dub.el
+++ b/flycheck-dmd-dub.el
@@ -88,8 +88,13 @@ PKG is a package name such as 'cerealed': '~master'."
 
 
 (defun fldd--get-dub-package-dirs-json (json)
-  "Return the directories where the packages are for this JSON assoclist."
-  (let ((packages (assq 'packages json)))
+  "Get package directories from dub output.
+Return the directories where the packages are for the assoclist
+in this JSON string.  Any characters before the first opening
+brace are discarded before parsing."
+  (let* ((data (json-read-from-string (replace-regexp-in-string "^\\([[:ascii:][:nonascii:]]*?\\){.*\\'" ""
+                                                                json nil nil 1)))
+         (packages (assq 'packages data)))
     (fldd--pkgs-to-dir-names packages)))
 
 
@@ -103,7 +108,7 @@ PKG is a package name such as 'cerealed': '~master'."
 (defun fldd--get-dub-package-dirs ()
   "Get package directories."
   (let ((default-directory (fldd--get-project-dir)))
-    (fldd--get-dub-package-dirs-json (json-read-from-string (shell-command-to-string "dub describe")))))
+    (fldd--get-dub-package-dirs-json (shell-command-to-string "dub describe"))))
 
 
 ;;;###autoload

--- a/tests/flycheck-dmd-dub-test.el
+++ b/tests/flycheck-dmd-dub-test.el
@@ -67,20 +67,25 @@
 
 
 (ert-deftest test-fldd--get-dub-package-dirs-json ()
-  "Test getting the package directories from a json object"
-  (should (equal (fldd--get-dub-package-dirs-json (json-read-from-string "{}")) nil))
-  (should (equal (fldd--get-dub-package-dirs-json (json-read-from-string "{\"packages\": []}")) nil))
+  "Test getting the package directories from a json string."
+  (should (equal (fldd--get-dub-package-dirs-json "{}") nil))
+  (should (equal (fldd--get-dub-package-dirs-json "{\"packages\": []}") nil))
   (should (equal (fldd--get-dub-package-dirs-json
-                  (json-read-from-string
-                   "{\"packages\": [{ \"path\": \"/foo/bar\", \"importPaths\": [\".\"]}] } "))
+                  "{\"packages\": [{ \"path\": \"/foo/bar\", \"importPaths\": [\".\"]}] } ")
                  '("/foo/bar")))
-    (should (equal (fldd--get-dub-package-dirs-json
-                  (json-read-from-string
-                   "{\"packages\": [
+  (should (equal (fldd--get-dub-package-dirs-json
+                  "{\"packages\": [
                         { \"path\": \"/foo/bar/source\", \"importPaths\": [\".\"]},
                         { \"path\": \"/blug/dlag/\", \"importPaths\": [\"source\"]}
-                   ]}"))
-                 '("/foo/bar/source" "/blug/dlag/source"))))
+                   ]}")
+                 '("/foo/bar/source" "/blug/dlag/source")))
+  (should (equal (fldd--get-dub-package-dirs-json
+                  "The following changes will be performed:\nFetch vibe-d >=0.7.17, userWide\n{}") nil))
+  (should (equal (fldd--get-dub-package-dirs-json
+                  "The following changes will be performed:\nFetch vibe-d >=0.7.17, userWide
+{\"packages\": [{ \"path\": \"/foo/bar\", \"importPaths\": [\".\"]}] } ")
+                 '("/foo/bar")))
+)
 
 (provide 'flycheck-dmd-dub-test)
 ;;; flycheck-dmd-dub-test.el ends here


### PR DESCRIPTION
JSON parsing moved to `fldd--get-dub-package-dirs-json` so that
`fldd--get-dub-package-dirs` doesn't have to think about it and the tests
don't have to call `json-read-from-string`.

`fldd--get-dub-package-dirs-json` strips any text prior to the first
opening brace character so that dub's prattle about installing modules
is tolerated.
