### PR TITLE
Support rename of flycheck-dmd-flags to flycheck-dmd-args

### DIFF
--- a/flycheck-dmd-dub.el
+++ b/flycheck-dmd-dub.el
@@ -174,7 +174,11 @@ other lines besides the json object."
              (import-paths (fldd--get-dub-package-dirs-output output))
              (string-import-paths (fldd--get-dub-package-string-import-paths-output output)))
         (setq flycheck-dmd-include-path import-paths)
-        (setq flycheck-dmd-flags (mapcar #'(lambda (x) (concat "-J" x)) string-import-paths))))))
+        (let ((flags (mapcar #'(lambda (x) (concat "-J" x)) string-import-paths)))
+          (cond ((symbolp 'flycheck-dmd-flags)
+                 (setq flycheck-dmd-flags flags))
+                ((symbolp 'flycheck-dmd-args)
+                 (setq flycheck-dmd-args flags))))))))
 
 
 (provide 'flycheck-dmd-dub)

--- a/flycheck-dmd-dub.el
+++ b/flycheck-dmd-dub.el
@@ -175,10 +175,9 @@ other lines besides the json object."
              (string-import-paths (fldd--get-dub-package-string-import-paths-output output)))
         (setq flycheck-dmd-include-path import-paths)
         (let ((flags (mapcar #'(lambda (x) (concat "-J" x)) string-import-paths)))
-          (cond ((symbolp 'flycheck-dmd-flags)
-                 (setq flycheck-dmd-flags flags))
-                ((symbolp 'flycheck-dmd-args)
-                 (setq flycheck-dmd-args flags))))))))
+          (if (version> (flycheck-version) "0.23")
+              (setq flycheck-dmd-args flags)
+            (setq flycheck-dmd-flags flags)))))))
 
 
 (provide 'flycheck-dmd-dub)


### PR DESCRIPTION
Support rename `flycheck-dmd-flags` to `flycheck-dmd-args` to match change in flycheck master.