### PR TITLE
Use cache file to reuse the result of dub describe

### DIFF
--- a/flycheck-dmd-dub.el
+++ b/flycheck-dmd-dub.el
@@ -185,7 +185,7 @@ If FILE does not exist, return nil."
   "File to cache the result of dub describe.")
 
 ;;;###autoload
-(defcustom flycheck-dmd-dub-use-cache-p t
+(defcustom flycheck-dmd-dub-use-cache-p nil
   "Non-nil means that `flycheck-dmd-dub-set-variables' reuses the result of dub describe by using cache file.")
 
 ;;;###autoload

--- a/flycheck-dmd-dub.el
+++ b/flycheck-dmd-dub.el
@@ -184,9 +184,16 @@ If FILE does not exist, return nil."
 (defvar fldd--cache-file ".fldd.cache"
   "File to cache the result of dub describe.")
 
+(defgroup flycheck-dmd-dub nil
+  "Sets flycheck-dmd-include-paths from dub package information"
+  :prefix "flycheck-dmd-dub-"
+  :group 'flycheck)
+
 ;;;###autoload
 (defcustom flycheck-dmd-dub-use-cache-p nil
-  "Non-nil means that `flycheck-dmd-dub-set-variables' reuses the result of dub describe by using cache file.")
+  "Non-nil means that `flycheck-dmd-dub-set-variables' reuses the result of dub describe by using cache file."
+  :type 'boolean
+  :group 'flycheck-dmd-dub)
 
 ;;;###autoload
 (defun flycheck-dmd-dub-set-include-path ()

--- a/flycheck-dmd-dub.el
+++ b/flycheck-dmd-dub.el
@@ -4,7 +4,7 @@
 
 ;; Author:  Atila Neves <atila.neves@gmail.com>
 ;; Version: 0.10
-;; Package-Requires: ((flycheck "0.24"))
+;; Package-Requires: ((flycheck "0.24") (f "0.18.2"))
 ;; Keywords: languages
 ;; URL: http://github.com/atilaneves/flycheck-dmd-dub
 
@@ -39,6 +39,7 @@
 
 (require 'json)
 (require 'flycheck)
+(require 'f)
 
 
 (defun fldd--dub-pkg-version-to-suffix (version)
@@ -161,6 +162,15 @@ other lines besides the json object."
   "Return the output from dub with package description."
   (shell-command-to-string "dub describe"))
 
+(defun fldd--get-timestamp (file)
+  "Return the timestamp of FILE.
+If FILE does not exist, return nil."
+  (when (file-exists-p file)
+    (nth 5 (file-attributes file))))
+
+(defvar fldd--cache-file ".fldd.cache"
+  "File to cache the result of dub describe.")
+
 
 ;;;###autoload
 (defun flycheck-dmd-dub-set-include-path ()
@@ -171,13 +181,25 @@ other lines besides the json object."
 
 ;;;###autoload
 (defun flycheck-dmd-dub-set-variables ()
-  "Set all flycheck-dmd variables."
+  "Set all flycheck-dmd variables.
+It also outputs the values of `import-paths' and `string-import-paths' to `fldd--cache-file'
+to reuse the result of dub describe."
   (let* ((basedir (fldd--get-project-dir)))
     (when basedir
       (let* ((default-directory basedir)
-             (output (shell-command-to-string "dub describe"))
-             (import-paths (fldd--get-dub-package-dirs-output output))
-             (string-import-paths (fldd--get-dub-package-string-import-paths-output output)))
+             (conf-timestamp (fldd--get-timestamp "dub.selections.json"))
+             (cache-timestamp (fldd--get-timestamp fldd--cache-file)))
+        (when (or (not conf-timestamp) (not cache-timestamp)
+                  (time-less-p cache-timestamp conf-timestamp))
+          (let* ((output (shell-command-to-string "dub describe"))
+                 (import-paths (fldd--get-dub-package-dirs-output output))
+                 (string-import-paths (fldd--get-dub-package-string-import-paths-output output))
+                 (cache-text (with-output-to-string
+                                 (print `((import-paths . ,import-paths)
+                                          (string-import-paths . ,string-import-paths))))))
+            (f-write cache-text 'utf-8 fldd--cache-file)))
+        (mapc (lambda (lst) (set (car lst) (cdr lst)))
+              (read (f-read fldd--cache-file)))
         (setq flycheck-dmd-include-path import-paths)
         (let ((flags (mapcar #'(lambda (x) (concat "-J" x)) string-import-paths)))
           (setq flycheck-dmd-args flags))))))


### PR DESCRIPTION
Currently, `flycheck-dmd-dub` invokes `dub describe` whenever we open D files in dub project even if these files belong to the same project and it takes long time to finish invoking `dub describe`.
This request solves this issue by introducing cache file for each dub project.

After merging this request, `flycheck-dmd-dub-set-variables` works as follows:
- It first checks the cache file `fldd--cache-file` in the project directory and `dub.selections.json` that contains all dependencies in the project (generated by `dub`).
- If some of them does not exist or `fldd--cache-file` is older than `dub.selections.json` (i.e. dependencies are updated after generating the cache file), `flycheck-dmd-dub-set-variables` invokes `dub describe` and outputs the values of `import-paths` and `string-import-paths` to the cache file. Otherwise `flycheck-dmd-dub-set-variables` skip updating the cache file.
- It reads `import-paths` and `string-import-paths` from the cache file and set them to flycheck-dmd variables.

It prevents `flycheck-dmd-dub-set-variables` from invoking `dub describe` when there is a latest cache file in a dub project.

I also added the dependency for `f` library to use `f-read` and `f-write`.

Note: I'm not sure that `.fldd.cache` (value of `fldd--cache-file`) is good file name for this purpose. Do you have any idea for that?
